### PR TITLE
Update the dependencies on the deprecated methods

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ var SlackChannelHistoryLogger = (function () {
         });
         var teamInfoResp = this.requestSlackAPI('team.info');
         this.teamName = teamInfoResp.team.name;
-        var channelsResp = this.requestSlackAPI('channels.list');
+        var channelsResp = this.requestSlackAPI('conversations.list');
         for (var _i = 0, _a = channelsResp.channels; _i < _a.length; _i++) {
             var ch = _a[_i];
             this.importChannelHistoryDelta(ch);
@@ -190,7 +190,7 @@ var SlackChannelHistoryLogger = (function () {
                 options['oldest'] = oldest;
             }
             // order: recent-to-older
-            var resp = _this.requestSlackAPI('channels.history', options);
+            var resp = _this.requestSlackAPI('conversations.history', options);
             messages = resp.messages.concat(messages);
             return resp;
         };
@@ -216,4 +216,4 @@ var SlackChannelHistoryLogger = (function () {
         });
     };
     return SlackChannelHistoryLogger;
-})();
+}());

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,12 +24,12 @@ interface ISlackResponse {
   error?:   string;
 }
 
-// https://api.slack.com/methods/channels.list
+// https://api.slack.com/methods/conversations.list
 interface ISlackChannelsListResponse extends ISlackResponse {
   channels: ISlackChannel[];
 }
 
-// https://api.slack.com/methods/channels.history
+// https://api.slack.com/methods/conversations.history
 interface ISlackChannelsHistoryResponse extends ISlackResponse {
   latest?: string;
   oldest?: string;
@@ -126,7 +126,7 @@ class SlackChannelHistoryLogger {
     let teamInfoResp = <ISlackTeamInfoResponse>this.requestSlackAPI('team.info');
     this.teamName = teamInfoResp.team.name;
 
-    let channelsResp = <ISlackChannelsListResponse>this.requestSlackAPI('channels.list');
+    let channelsResp = <ISlackChannelsListResponse>this.requestSlackAPI('conversations.list');
     for (let ch of channelsResp.channels) {
       this.importChannelHistoryDelta(ch);
     }
@@ -277,7 +277,7 @@ class SlackChannelHistoryLogger {
         options['oldest'] = oldest;
       }
       // order: recent-to-older
-      let resp = <ISlackChannelsHistoryResponse>this.requestSlackAPI('channels.history', options);
+      let resp = <ISlackChannelsHistoryResponse>this.requestSlackAPI('conversations.history', options);
       messages = resp.messages.concat(messages);
       return resp;
     }


### PR DESCRIPTION
Two of the API methods used in the script, [channels.list](https://api.slack.com/methods/channels.list) and [channels.history](https://api.slack.com/methods/channels.history), have been deprecated. We need to update them.